### PR TITLE
:bug:  workflowが発火しないため、pathsのパターンを修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
       - master
     types: [closed]
     paths:
+      - './**'
       - '!.commit_template'
       - '!.eslintignore'
       - '!.eslintrc'


### PR DESCRIPTION
* pathsが除外パターンのみになっており、発火パターンがなかったためworkflowが動かなった。そこで、'./**'で全てのファイル・ディレクトリで発火するように変更。